### PR TITLE
Add Next.js types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,3 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
-next-env.d.ts

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+


### PR DESCRIPTION
## Summary
- track `next-env.d.ts` so Next.js build gets proper type definitions
- stop ignoring `next-env.d.ts`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871de11833c83239698860df63795ea