### PR TITLE
Fix dynamic blog page typing

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -3,12 +3,17 @@ import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import { getPostSlugs, getPostBySlug } from "@/lib/posts";
 
-export async function generateStaticParams() {
+export async function generateStaticParams(): Promise<{ slug: string }[]> {
   // Return array of plain objects { slug: string }
   return getPostSlugs().map((slug) => ({ slug: slug.replace(/\.mdx?$/, "") }));
 }
 
-export default async function Page({ params }: { params: { slug: string } }) {
+interface PageProps {
+  params: {
+    slug: string;
+  };
+}
+export default async function Page({ params }: PageProps) {
   try {
     const post = await getPostBySlug(params.slug);
     const { frontmatter, mdxSource } = post;


### PR DESCRIPTION
## Summary
- add explicit return type to `generateStaticParams`
- define a `PageProps` interface for `[slug]` page
- use the new `PageProps` interface in the page component

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871e169c140832397b6bacef5a87955