### PR TITLE
Fix Tailwind content path for markdown posts

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,7 @@ module.exports = {
     "./src/app/**/*.{js,jsx,ts,tsx,mdx}",
     "./src/components/**/*.{js,jsx,ts,tsx,mdx}",
     "./src/lib/posts.ts",
+    "./src/data/posts/**/*.{md,mdx}",
   ],
   darkMode: "class", // your choice: 'media' or 'class'
   theme: {


### PR DESCRIPTION
## Summary
- scan Markdown and MDX blog posts for Tailwind classes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6872e4e652b883238d986b6b17fe9204