### PR TITLE
Fix font compatibility and add Geist fonts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "deep-thoughts-blog",
       "version": "0.1.0",
       "dependencies": {
+        "geist": "^1.4.2",
         "gray-matter": "^4.0.3",
         "lucide-react": "^0.525.0",
         "next": "^15.3.5",
@@ -29,6 +30,9 @@
         "prettier": "^3.6.2",
         "tailwindcss": "^4.1.11",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -3997,6 +4001,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/geist": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/geist/-/geist-1.4.2.tgz",
+      "integrity": "sha512-OQUga/KUc8ueijck6EbtT07L4tZ5+TZgjw8PyWfxo16sL5FWk7gNViPNU8hgCFjy6bJi9yuTP+CRpywzaGN8zw==",
+      "license": "SIL OPEN FONT LICENSE",
+      "peerDependencies": {
+        "next": ">=13.2.0"
       }
     },
     "node_modules/get-east-asian-width": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "geist": "^1.4.2",
     "gray-matter": "^4.0.3",
     "lucide-react": "^0.525.0",
     "next": "^15.3.5",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import "@/styles/globals.css"; // your global Tailwind CSS
 import type { ReactNode } from "react";
 import Header from "@/components/Header"; // your header
 import Footer from "@/components/Footer"; // your footer
+import { GeistSans } from "geist/font/sans";
+import { GeistMono } from "geist/font/mono";
 
 export const metadata = {
   title: "Deep Thoughts",
@@ -11,7 +13,10 @@ export const metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" className="antialiased">
+    <html
+      lang="en"
+      className={`antialiased ${GeistSans.variable} ${GeistMono.variable}`}
+    >
       <body
         className="flex flex-col min-h-screen 
                        bg-white text-gray-800 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,7 +11,12 @@ module.exports = {
   ],
   darkMode: "class", // your choice: 'media' or 'class'
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ["var(--font-geist-sans)"],
+        mono: ["var(--font-geist-mono)"],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- add Geist font package
- wire up GeistSans and GeistMono in layout
- configure Tailwind to use Geist fonts

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687662a9db5c832393db62a052425fdb