### PR TITLE
Fix blog page typing for Next.js PageProps

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -17,7 +17,7 @@ const mdxComponents = {
   Callout,
 };
 
-export function generateStaticParams() {
+export async function generateStaticParams(): Promise<Array<{ slug: string }>> {
   const slugs = getPostSlugs()
     .filter(
       (filename: string) =>
@@ -28,12 +28,12 @@ export function generateStaticParams() {
   return slugs.map((slug: string) => ({ slug }));
 }
 
-interface Props {
-  params: { slug: string };
+interface PageProps {
+  params: Promise<{ slug: string }>;
 }
 
-export default async function Page({ params }: Props) {
-  const { slug } = params;
+export default async function Page({ params }: PageProps) {
+  const { slug } = await params;
 
   let post;
   try {


### PR DESCRIPTION
## Summary
- update the blog slug page to use the Next.js 15 PageProps shape
- await the promised params value before reading the slug
- adjust generateStaticParams to return a promise for stronger typing

## Testing
- npm run build *(fails: next/font cannot download Google Fonts in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_6901fc36e15c8323930b4a8bf162a667